### PR TITLE
Fix integration with IntelOwl

### DIFF
--- a/iris_intelowl_module/IrisIntelowlConfig.py
+++ b/iris_intelowl_module/IrisIntelowlConfig.py
@@ -11,7 +11,7 @@
 module_name = "Iris IntelOwl"
 module_description = "Provides a connector with IntelOwl - allows to pull insights from IntelOwl analyzers"
 interface_version = "1.2.0"
-module_version = "0.1.0"
+module_version = "0.1.1"
 
 pipeline_support = False
 pipeline_info = {}

--- a/iris_intelowl_module/intelowl_handler/intelowl_handler.py
+++ b/iris_intelowl_module/intelowl_handler/intelowl_handler.py
@@ -222,7 +222,7 @@ class IntelowlHandler(object):
         domain = ioc.ioc_value
         try:
             query_result = self.intelowl.send_observable_analysis_playbook_request(observable_name=domain,
-                                                                                   playbooks_requested=["FREE_TO_USE_ANALYZERS"],
+                                                                                   playbook_requested="FREE_TO_USE_ANALYZERS",
                                                                                    tags_labels=["iris"],
                                                                                    observable_classification="domain")
         except IntelOwlClientException as e:
@@ -276,7 +276,7 @@ class IntelowlHandler(object):
         ip = ioc.ioc_value
         try:
             query_result = self.intelowl.send_observable_analysis_playbook_request(observable_name=ip,
-                                                                                   playbooks_requested=["FREE_TO_USE_ANALYZERS"],
+                                                                                   playbook_requested="FREE_TO_USE_ANALYZERS",
                                                                                    tags_labels=["iris"],
                                                                                    observable_classification="ip")
         except IntelOwlClientException as e:
@@ -329,7 +329,7 @@ class IntelowlHandler(object):
         url = ioc.ioc_value
         try:
             query_result = self.intelowl.send_observable_analysis_playbook_request(observable_name=url,
-                                                                                   playbooks_requested=["FREE_TO_USE_ANALYZERS"],
+                                                                                   playbook_requested="FREE_TO_USE_ANALYZERS",
                                                                                    tags_labels=["iris"],
                                                                                    observable_classification="url")
         except IntelOwlClientException as e:
@@ -382,7 +382,7 @@ class IntelowlHandler(object):
         hash = ioc.ioc_value
         try:
             query_result = self.intelowl.send_observable_analysis_playbook_request(observable_name=hash,
-                                                                                   playbooks_requested=["FREE_TO_USE_ANALYZERS"],
+                                                                                   playbook_requested="FREE_TO_USE_ANALYZERS",
                                                                                    tags_labels=["iris"],
                                                                                    observable_classification="hash")
         except IntelOwlClientException as e:
@@ -435,7 +435,7 @@ class IntelowlHandler(object):
         generic = ioc.ioc_value
         try:
             query_result = self.intelowl.send_observable_analysis_playbook_request(observable_name=generic,
-                                                                                   playbooks_requested=["FREE_TO_USE_ANALYZERS"],
+                                                                                   playbook_requested="FREE_TO_USE_ANALYZERS",
                                                                                    tags_labels=["iris"],
                                                                                    observable_classification="generic")
         except IntelOwlClientException as e:

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 setup(
     name='iris-intelowl-module',
     python_requires='>=3.8',
-    version='0.1.0',
+    version='0.1.1',
     packages=['iris_intelowl_module', 'iris_intelowl_module.intelowl_handler'],
     url='https://github.com/dfir-iris/iris-intelowl-module',
     license='Apache Software License 3.0',


### PR DESCRIPTION
I've been trying to use IntelOwl from dfir-iris and looked at documentation for pyintelowl and saw that the parameter should be playbook_requested (singular without s) and that it should be a string. Bumped version number for my own and included it in this commit.
Should solve #2 if a wheel is built and included in the main repository.